### PR TITLE
SENE-13 mimemagicのGPL汚染対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.4)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)


### PR DESCRIPTION
下記通り、GPL汚染の発生により使用していたmimemagicのバージョンがyankされたため、最新化する。
https://daiconnnnnnn.hatenablog.com/entry/2021/03/25/235009